### PR TITLE
fix: CHALKY-1944 Date values in a query sets seconds/milliseconds to 0 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-02-10
+### Added
+- Date values used in query expressions have time precision set to whole minutes by default in *between*, *lessThan*, *lessThanOrEqualTo*, *greaterThan*, and *greaterThanOrEqualTo* operators
+- Added *timePrecision* argument to the above operator constructor methods
+
 ## [1.2.1] - 2025-06-02
 ### Added
 - Missing enums for Forms and Tags

--- a/src/models/search/ExpressionTimePrecision.ts
+++ b/src/models/search/ExpressionTimePrecision.ts
@@ -1,0 +1,7 @@
+export type ExpressionTimePrecision = 'minutes' | 'seconds' | 'exact';
+
+export const ExpressionTimePrecisionEnum = {
+    Minutes: 'minutes' as ExpressionTimePrecision,
+    Seconds: 'seconds' as ExpressionTimePrecision,
+    Exact: 'exact' as ExpressionTimePrecision
+};

--- a/src/models/search/Operators.ts
+++ b/src/models/search/Operators.ts
@@ -1,5 +1,7 @@
 import { ContensisQueryOperators, ExpressionValueType, ExpressionValueTypeEnum, IExpression, ILogicalExpression, OperatorType, OperatorTypeEnum } from '..';
+import { fixDates } from '../../utils';
 import { DistanceSearch } from './DistanceSearch';
+import { ExpressionTimePrecision, ExpressionTimePrecisionEnum as TimePrecision } from './ExpressionTimePrecision';
 import { FreeTextSearch } from './FreeTextSearch';
 import { FreeTextSearchOperatorType, FreeTextSearchOperatorTypeEnum } from './FreeTextSearchOperatorType';
 
@@ -110,8 +112,8 @@ class AndExpression extends LogicalExpression {
     }
 }
 class BetweenExpression extends ExpressionBase {
-    constructor(fieldName: string, minimum: any, maximum: any) {
-        super(fieldName, [minimum, maximum], OperatorTypeEnum.Between, ExpressionValueTypeEnum.Array);
+    constructor(fieldName: string, minimum: any, maximum: any, timePrecision: ExpressionTimePrecision) {
+        super(fieldName, fixDates([minimum, maximum], timePrecision), OperatorTypeEnum.Between, ExpressionValueTypeEnum.Array);
     }
 }
 class ContainsExpression extends ExpressionBase {
@@ -145,13 +147,13 @@ class FreeTextExpression extends ExpressionBase {
     }
 }
 class GreaterThanExpression extends ExpressionBase {
-    constructor(fieldName: string, value: any) {
-        super(fieldName, [value], OperatorTypeEnum.GreaterThan, ExpressionValueTypeEnum.Single);
+    constructor(fieldName: string, value: any, timePrecision: ExpressionTimePrecision) {
+        super(fieldName, fixDates([value], timePrecision), OperatorTypeEnum.GreaterThan, ExpressionValueTypeEnum.Single);
     }
 }
 class GreaterThanOrEqualToExpression extends ExpressionBase {
-    constructor(fieldName: string, value: any) {
-        super(fieldName, [value], OperatorTypeEnum.GreaterThanOrEqualTo, ExpressionValueTypeEnum.Single);
+    constructor(fieldName: string, value: any, timePrecision: ExpressionTimePrecision) {
+        super(fieldName, fixDates([value], timePrecision), OperatorTypeEnum.GreaterThanOrEqualTo, ExpressionValueTypeEnum.Single);
     }
 }
 class InExpression extends ExpressionBase {
@@ -160,13 +162,13 @@ class InExpression extends ExpressionBase {
     }
 }
 class LessThanExpression extends ExpressionBase {
-    constructor(fieldName: string, value: any) {
-        super(fieldName, [value], OperatorTypeEnum.LessThan, ExpressionValueTypeEnum.Single);
+    constructor(fieldName: string, value: any, timePrecision: ExpressionTimePrecision) {
+        super(fieldName, fixDates([value], timePrecision), OperatorTypeEnum.LessThan, ExpressionValueTypeEnum.Single);
     }
 }
 class LessThanOrEqualToExpression extends ExpressionBase {
-    constructor(fieldName: string, value: any) {
-        super(fieldName, [value], OperatorTypeEnum.LessThanOrEqualTo, ExpressionValueTypeEnum.Single);
+    constructor(fieldName: string, value: any, timePrecision: ExpressionTimePrecision) {
+        super(fieldName, fixDates([value], timePrecision), OperatorTypeEnum.LessThanOrEqualTo, ExpressionValueTypeEnum.Single);
     }
 }
 class NotExpression extends LogicalExpression {
@@ -201,8 +203,8 @@ export class Operators implements ContensisQueryOperators {
         return new AndExpression(values);
     }
 
-    between(name: string, minimum: any, maximum: any): IExpression {
-        return new BetweenExpression(name, minimum, maximum);
+    between(name: string, minimum: any, maximum: any, timePrecision: ExpressionTimePrecision = TimePrecision.Minutes): IExpression {
+        return new BetweenExpression(name, minimum, maximum, timePrecision);
     }
 
     contains(name: string, value: string): IExpression {
@@ -229,24 +231,24 @@ export class Operators implements ContensisQueryOperators {
         return new FreeTextExpression(name, { term, fuzzy, operator });
     }
 
-    greaterThan(name: string, value: any): IExpression {
-        return new GreaterThanExpression(name, value);
+    greaterThan(name: string, value: any, timePrecision: ExpressionTimePrecision = TimePrecision.Minutes): IExpression {
+        return new GreaterThanExpression(name, value, timePrecision);
     }
 
-    greaterThanOrEqualTo(name: string, value: any): IExpression {
-        return new GreaterThanOrEqualToExpression(name, value);
+    greaterThanOrEqualTo(name: string, value: any, timePrecision: ExpressionTimePrecision = TimePrecision.Minutes): IExpression {
+        return new GreaterThanOrEqualToExpression(name, value, timePrecision);
     }
 
     in(name: string, ...values: any[]): IExpression {
         return new InExpression(name, values);
     }
 
-    lessThan(name: string, value: any): IExpression {
-        return new LessThanExpression(name, value);
+    lessThan(name: string, value: any, timePrecision: ExpressionTimePrecision = TimePrecision.Minutes): IExpression {
+        return new LessThanExpression(name, value, timePrecision);
     }
 
-    lessThanOrEqualTo(name: string, value: any): IExpression {
-        return new LessThanOrEqualToExpression(name, value);
+    lessThanOrEqualTo(name: string, value: any, timePrecision: ExpressionTimePrecision = TimePrecision.Minutes): IExpression {
+        return new LessThanOrEqualToExpression(name, value, timePrecision);
     }
 
     not(expression: IExpression): ILogicalExpression {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,10 +68,12 @@ export let defaultMapperForLatestVersionStatus: MapperFn = (value: string, optio
 /**
  * Prevent users from unintentionally providing date values with seconds or milliseconds that break request caching.
  * For each top-level entry in the `values` array that is a Date object or a string
- * that can be parsed as a date, zero the seconds and milliseconds from the value if timePrecision
- * is not set to 'exact'.
+ * that can be parsed as a date, the value is normalized according to `timePrecision`:
+ * - `'minutes'`: seconds and milliseconds are set to 0.
+ * - `'seconds'`: seconds are preserved and milliseconds are set to 0.
+ * - `'exact'`: the original value is preserved unchanged.
  * @param values - array of values provided to the query operator; each top-level Date or date-like string will be transformed
- * @param timePrecision - if set to 'minutes' or 'seconds' the relevant parts of the date will be set to 0
+ * @param timePrecision - controls how precisely time information is preserved: `'minutes'`, `'seconds'`, or `'exact'`
  */
 export const fixDates = (values: any[], timePrecision: ExpressionTimePrecision) => {
 	if (timePrecision === 'exact') return values;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { MapperFn, ClientParams, VersionStatus } from './models';
 import * as isNode from 'detect-node';
+import { ExpressionTimePrecision } from './models/search/ExpressionTimePrecision';
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
@@ -63,3 +64,41 @@ export let defaultMapperForPublishedVersionStatus: MapperFn = (value: string, op
 
 export let defaultMapperForLatestVersionStatus: MapperFn = (value: string, options: any, params: ClientParams) =>
 	(value as VersionStatus === 'latest') ? null : value;
+
+/**
+ * Prevent users from unintentionally providing date values with seconds or milliseconds that break request caching
+ * Examine the provided value for any Date objects or strings that can be parsed as dates
+ * and zero the seconds and milliseconds from the value if timePrecision is not set to 'exact'
+ * @param values - the value provided to the query operator that may contain dates that need to be transformed
+ * @param timePrecision - if set to 'minutes' or 'seconds' the relevant parts of the date will be set to 0
+ */
+export const fixDates = (values: any[], timePrecision: ExpressionTimePrecision) => {
+	if (timePrecision === 'exact') return values;
+
+	try {
+		return values.map(value => {
+			const fixDate = value instanceof Date
+				? value
+				: ((isString(value) && !isNaN(Date.parse(value)))
+					? new Date(value) : null);
+
+			if (fixDate instanceof Date) {
+				// Preserve timezone by manipulating UTC fields
+				const year = fixDate.getUTCFullYear();
+				const month = fixDate.getUTCMonth();
+				const date = fixDate.getUTCDate();
+				const hours = fixDate.getUTCHours();
+				const minutes = fixDate.getUTCMinutes();
+				const seconds = timePrecision === 'minutes' ? 0 : fixDate.getUTCSeconds();
+				const ms = (timePrecision === 'minutes' || timePrecision === 'seconds')
+					? 0 : fixDate.getUTCMilliseconds();
+
+				return new Date(Date.UTC(year, month, date, hours, minutes, seconds, ms));
+			}
+		});
+	} catch (e: any) {
+		// if any error occurs just return the original values
+		console.warn('fixDates failed', e);
+		return values;
+	}
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
-import { MapperFn, ClientParams, VersionStatus } from './models';
+import type { MapperFn, ClientParams, VersionStatus } from './models';
 import * as isNode from 'detect-node';
-import { ExpressionTimePrecision } from './models/search/ExpressionTimePrecision';
+import type { ExpressionTimePrecision } from './models/search/ExpressionTimePrecision';
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
@@ -66,10 +66,11 @@ export let defaultMapperForLatestVersionStatus: MapperFn = (value: string, optio
 	(value as VersionStatus === 'latest') ? null : value;
 
 /**
- * Prevent users from unintentionally providing date values with seconds or milliseconds that break request caching
- * Examine the provided value for any Date objects or strings that can be parsed as dates
- * and zero the seconds and milliseconds from the value if timePrecision is not set to 'exact'
- * @param values - the value provided to the query operator that may contain dates that need to be transformed
+ * Prevent users from unintentionally providing date values with seconds or milliseconds that break request caching.
+ * For each top-level entry in the `values` array that is a Date object or a string
+ * that can be parsed as a date, zero the seconds and milliseconds from the value if timePrecision
+ * is not set to 'exact'.
+ * @param values - array of values provided to the query operator; each top-level Date or date-like string will be transformed
  * @param timePrecision - if set to 'minutes' or 'seconds' the relevant parts of the date will be set to 0
  */
 export const fixDates = (values: any[], timePrecision: ExpressionTimePrecision) => {
@@ -81,23 +82,23 @@ export const fixDates = (values: any[], timePrecision: ExpressionTimePrecision) 
 				? value
 				: ((isString(value) && !isNaN(Date.parse(value)))
 					? new Date(value) : null);
+			if (!fixDate) return value;
 
-			if (fixDate instanceof Date) {
-				// Preserve timezone by manipulating UTC fields
-				const year = fixDate.getUTCFullYear();
-				const month = fixDate.getUTCMonth();
-				const date = fixDate.getUTCDate();
-				const hours = fixDate.getUTCHours();
-				const minutes = fixDate.getUTCMinutes();
-				const seconds = timePrecision === 'minutes' ? 0 : fixDate.getUTCSeconds();
-				const ms = (timePrecision === 'minutes' || timePrecision === 'seconds')
-					? 0 : fixDate.getUTCMilliseconds();
+			// Preserve timezone by manipulating UTC fields
+			const year = fixDate.getUTCFullYear();
+			const month = fixDate.getUTCMonth();
+			const date = fixDate.getUTCDate();
+			const hours = fixDate.getUTCHours();
+			const minutes = fixDate.getUTCMinutes();
+			const seconds = timePrecision === 'minutes' ? 0 : fixDate.getUTCSeconds();
+			const ms = (timePrecision === 'minutes' || timePrecision === 'seconds')
+				? 0 : fixDate.getUTCMilliseconds();
 
-				return new Date(Date.UTC(year, month, date, hours, minutes, seconds, ms));
-			}
+			return new Date(Date.UTC(year, month, date, hours, minutes, seconds, ms));
 		});
 	} catch (e: any) {
 		// if any error occurs just return the original values
+		// TODO: remove the console warning after we are confident there are no issues with the date manipulation logic
 		console.warn('fixDates failed', e);
 		return values;
 	}


### PR DESCRIPTION
in `between`, `greaterThan...` and `lessThan...` operators to avoid queries that cannot be cached effectively

Solution agreed with Mark S and Si and the approach semantics negotiated and reviewed with Mark.

I have completed the changelog

TODO:
* bump version to 1.2.2
* publish package
* update contensis-delivery-api dependency
* push test added to entry-operations.spec.js

